### PR TITLE
Fix duplicate namespace with Drupal core

### DIFF
--- a/AttributeExtension.php
+++ b/AttributeExtension.php
@@ -2,7 +2,7 @@
 
 namespace Parisek\Twig;
 
-use Drupal\Core\Template\AttributeCollection;
+use Drupal\Component\Attribute\AttributeCollection;
 use Twig\Extension\AbstractExtension;
 use Twig\TwigFunction;
 use Twig\Environment;

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Drupal\\Core\\Template\\": "src",
+            "Drupal\\Component\\Attribute\\": "src",
             "Parisek\\Twig\\": ""
         }
     }

--- a/src/AttributeArray.php
+++ b/src/AttributeArray.php
@@ -1,34 +1,34 @@
 <?php
 
-namespace Drupal\Core\Template;
+namespace Drupal\Component\Attribute;
 
 use Drupal\Component\Utility\Html;
 
 /**
  * A class that defines a type of Attribute that can be added to as an array.
  *
- * To use with Attribute, the array must be specified.
+ * To use with AttributeCollection, the array must be specified.
  * Correct:
  * @code
- *  $attributes = new Attribute();
- *  $attributes['class'] = array();
+ *  $attributes = new AttributeCollection();
+ *  $attributes['class'] = [];
  *  $attributes['class'][] = 'cat';
  * @endcode
  * Incorrect:
  * @code
- *  $attributes = new Attribute();
+ *  $attributes = new AttributeCollection();
  *  $attributes['class'][] = 'cat';
  * @endcode
  *
- * @see \Drupal\Core\Template\Attribute
+ * @see \Drupal\Component\Attribute\AttributeCollection
  */
 class AttributeArray extends AttributeValueBase implements \ArrayAccess, \IteratorAggregate {
 
   /**
    * Ensures empty array as a result of array_filter will not print '$name=""'.
    *
-   * @see \Drupal\Core\Template\AttributeArray::__toString()
-   * @see \Drupal\Core\Template\AttributeValueBase::render()
+   * @see \Drupal\Component\Attribute\AttributeArray::__toString()
+   * @see \Drupal\Component\Attribute\AttributeValueBase::render()
    */
   const RENDER_EMPTY_ATTRIBUTE = FALSE;
 

--- a/src/AttributeBoolean.php
+++ b/src/AttributeBoolean.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Core\Template;
+namespace Drupal\Component\Attribute;
 
 use Drupal\Component\Utility\Html;
 
@@ -11,9 +11,9 @@ use Drupal\Component\Utility\Html;
  * They are attributes that if they exist in the tag, they are TRUE.
  * Examples include selected, disabled, checked, readonly.
  *
- * To set a boolean attribute on the Attribute class, set it to TRUE.
+ * To set a boolean attribute on the AttributeCollection class, set it to TRUE.
  * @code
- *  $attributes = new Attribute();
+ *  $attributes = new AttributeCollection();
  *  $attributes['disabled'] = TRUE;
  *  echo '<select' . $attributes . '/>';
  *  // produces <select disabled>;
@@ -22,7 +22,7 @@ use Drupal\Component\Utility\Html;
  *  // produces <select>;
  * @endcode
  *
- * @see \Drupal\Core\Template\Attribute
+ * @see \Drupal\Component\Attribute\AttributeCollection
  */
 class AttributeBoolean extends AttributeValueBase {
 

--- a/src/AttributeCollection.php
+++ b/src/AttributeCollection.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Drupal\Core\Template;
+namespace Drupal\Component\Attribute;
 
 use Drupal\Component\Render\PlainTextOutput;
 use Drupal\Component\Render\MarkupInterface;
@@ -12,8 +12,8 @@ use Drupal\Component\Utility\NestedArray;
  * To use, optionally pass in an associative array of defined attributes, or
  * add attributes using array syntax. For example:
  * @code
- *  $attributes = new Attribute(array('id' => 'socks'));
- *  $attributes['class'] = array('black-cat', 'white-cat');
+ *  $attributes = new AttributeCollection(['id' => 'socks']);
+ *  $attributes['class'] = ['black-cat', 'white-cat'];
  *  $attributes['class'][] = 'black-white-cat';
  *  echo '<cat' . $attributes . '>';
  *  // Produces <cat id="socks" class="black-cat white-cat black-white-cat">
@@ -21,8 +21,8 @@ use Drupal\Component\Utility\NestedArray;
  *
  * $attributes always prints out all the attributes. For example:
  * @code
- *  $attributes = new Attribute(array('id' => 'socks'));
- *  $attributes['class'] = array('black-cat', 'white-cat');
+ *  $attributes = new AttributeCollection(['id' => 'socks']);
+ *  $attributes['class'] = ['black-cat', 'white-cat'];
  *  $attributes['class'][] = 'black-white-cat';
  *  echo '<cat class="cat ' . $attributes['class'] . '"' . $attributes . '>';
  *  // Produces <cat class="cat black-cat white-cat black-white-cat" id="socks" class="cat black-cat white-cat black-white-cat">
@@ -47,7 +47,7 @@ use Drupal\Component\Utility\NestedArray;
  * @code
  *  $path = 'javascript:alert("xss");';
  *  $path = UrlHelper::stripDangerousProtocols($path);
- *  $attributes = new Attribute(array('href' => $path));
+ *  $attributes = new AttributeCollection(['href' => $path]);
  *  echo '<a' . $attributes . '>';
  *  // Produces <a href="alert(&quot;xss&quot;);">
  * @endcode
@@ -57,7 +57,7 @@ use Drupal\Component\Utility\NestedArray;
  * PlainTextOutput::renderFromHtml() before being escaped. For example:
  * @code
  *   $value = t('Highlight the @tag tag', ['@tag' => '<em>']);
- *   $attributes = new Attribute(['value' => $value]);
+ *   $attributes = new AttributeCollection(['value' => $value]);
  *   echo '<input' . $attributes . '>';
  *   // Produces <input value="Highlight the &lt;em&gt; tag">
  * @endcode
@@ -71,12 +71,12 @@ class AttributeCollection implements \ArrayAccess, \IteratorAggregate, MarkupInt
   /**
    * Stores the attribute data.
    *
-   * @var \Drupal\Core\Template\AttributeValueBase[]
+   * @var \Drupal\Component\Attribute\AttributeValueBase[]
    */
   protected $storage = [];
 
   /**
-   * Constructs a \Drupal\Core\Template\Attribute object.
+   * Constructs a \Drupal\Component\Attribute\AttributeCollection object.
    *
    * @param array $attributes
    *   An associative array of key-value pairs to be converted to attributes.
@@ -113,7 +113,7 @@ class AttributeCollection implements \ArrayAccess, \IteratorAggregate, MarkupInt
    * @param mixed $value
    *   The attribute value.
    *
-   * @return \Drupal\Core\Template\AttributeValueBase
+   * @return \Drupal\Component\Attribute\AttributeValueBase
    *   An AttributeValueBase representation of the attribute's value.
    */
   protected function createAttributeValue($name, $value) {
@@ -289,7 +289,7 @@ class AttributeCollection implements \ArrayAccess, \IteratorAggregate, MarkupInt
    *
    * This method is implemented to take precedence over hasClass() for Twig 2.0.
    *
-   * @return \Drupal\Core\Template\AttributeValueBase
+   * @return \Drupal\Component\Attribute\AttributeValueBase
    *   The class attribute value if set.
    *
    * @see twig_get_attribute()
@@ -321,8 +321,8 @@ class AttributeCollection implements \ArrayAccess, \IteratorAggregate, MarkupInt
    */
   public function __toString() {
     $return = '';
-    /** @var \Drupal\Core\Template\AttributeValueBase $value */
     foreach ($this->storage as $value) {
+    /** @var \Drupal\Component\Attribute\AttributeValueBase $value */
       $rendered = $value->render();
       if ($rendered) {
         $return .= ' ' . $rendered;
@@ -384,12 +384,12 @@ class AttributeCollection implements \ArrayAccess, \IteratorAggregate, MarkupInt
   /**
    * Merges an Attribute object into the current storage.
    *
-   * @param \Drupal\Core\Template\Attribute $collection
+   * @param \Drupal\Component\Attribute\AttributeCollection $collection
    *   The Attribute object to merge.
    *
    * @return $this
    */
-  public function merge(Attribute $collection) {
+  public function merge(AttributeCollection $collection) {
     $merged_attributes = NestedArray::mergeDeep($this->toArray(), $collection->toArray());
     foreach ($merged_attributes as $name => $value) {
       $this->storage[$name] = $this->createAttributeValue($name, $value);

--- a/src/AttributeString.php
+++ b/src/AttributeString.php
@@ -1,23 +1,23 @@
 <?php
 
-namespace Drupal\Core\Template;
+namespace Drupal\Component\Attribute;
 
 use Drupal\Component\Utility\Html;
 
 /**
  * A class that represents most standard HTML attributes.
  *
- * To use with the Attribute class, set the key to be the attribute name
- * and the value the attribute value.
+ * To use with the AttributeCollection class, set the key to be the attribute
+ * name and the value the attribute value.
  * @code
- *  $attributes = new Attribute(array());
+ *  $attributes = new AttributeCollection([]);
  *  $attributes['id'] = 'socks';
  *  $attributes['style'] = 'background-color:white';
  *  echo '<cat ' . $attributes . '>';
  *  // Produces: <cat id="socks" style="background-color:white">.
  * @endcode
  *
- * @see \Drupal\Core\Template\Attribute
+ * @see \Drupal\Component\Attribute\AttributeCollection
  */
 class AttributeString extends AttributeValueBase {
 

--- a/src/AttributeValueBase.php
+++ b/src/AttributeValueBase.php
@@ -1,20 +1,20 @@
 <?php
 
-namespace Drupal\Core\Template;
+namespace Drupal\Component\Attribute;
 
 use Drupal\Component\Utility\Html;
 
 /**
  * Defines the base class for an attribute type.
  *
- * @see \Drupal\Core\Template\Attribute
+ * @see \Drupal\Component\Attribute\AttributeCollection
  */
 abstract class AttributeValueBase {
 
   /**
    * Renders '$name=""' if $value is an empty string.
    *
-   * @see \Drupal\Core\Template\AttributeValueBase::render()
+   * @see \Drupal\Component\Attribute\AttributeValueBase::render()
    */
   const RENDER_EMPTY_ATTRIBUTE = TRUE;
 
@@ -33,7 +33,7 @@ abstract class AttributeValueBase {
   protected $name;
 
   /**
-   * Constructs a \Drupal\Core\Template\AttributeValueBase object.
+   * Constructs a \Drupal\Component\Attribute\AttributeValueBase object.
    */
   public function __construct($name, $value) {
     $this->name = $name;


### PR DESCRIPTION
```
Warning: Ambiguous class resolution, "Drupal\Core\Template\AttributeString" was found in both "/var/www/html/vendor/parisek/twig-attribute/src/AttributeString.php" and "/var/www/html/web/core/lib/Drupal/Core/Template/AttributeString.php", the first will be used.
Warning: Ambiguous class resolution, "Drupal\Core\Template\AttributeBoolean" was found in both "/var/www/html/vendor/parisek/twig-attribute/src/AttributeBoolean.php" and "/var/www/html/web/core/lib/Drupal/Core/Template/AttributeBoolean.php", the first will be used.
Warning: Ambiguous class resolution, "Drupal\Core\Template\AttributeValueBase" was found in both "/var/www/html/vendor/parisek/twig-attribute/src/AttributeValueBase.php" and "/var/www/html/web/core/lib/Drupal/Core/Template/AttributeValueBase.php", the first will be used.
Warning: Ambiguous class resolution, "Drupal\Core\Template\AttributeArray" was found in both "/var/www/html/vendor/parisek/twig-attribute/src/AttributeArray.php" and "/var/www/html/web/core/lib/Drupal/Core/Template/AttributeArray.php", the first will be used.
```