### PR TITLE
Address Copilot review + rename 1.1.0 → 1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
-## [1.1.0] - YYYY-MM-DD
+## [1.6.0] - 2026-05-25
 
 ### Added
 - 543-LOC PHPUnit test suite ported from Drupal 11.x core `AttributeTest.php`
@@ -16,7 +16,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   - `hasAttribute(string $name): bool`
   - `removeClass(...$classes): static`
   - `getClass(): AttributeArray`
-  - `jsonSerialize(): array`
+  - `jsonSerialize(): string` (returns the rendered attribute string)
   - `__clone()` for deep-clone correctness.
 - `Parisek\Twig\Internal\Escape::html()` — byte-identical inline replacement for
   Drupal's `Html::escape()` (5 LOC, `htmlspecialchars` with
@@ -46,10 +46,10 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 - `twig/twig ^2.4` support dropped. Twig 3+ only.
 
 ### Semver rationale
-Shipped as **1.1.0** rather than 2.0.0 because the tightened constraints
+Shipped as **1.6.0** rather than 2.0.0 because the tightened constraints
 (`php: ^8.3`, `twig/twig: ^3.0`) match what was already implied transitively
-by `drupal/core-utility ^10.0 || ^11.0` in 1.0.x — anyone who could install
-1.0.x against modern Drupal already had PHP 8.3+ and Twig 3+. The pruned
+by `drupal/core-utility ^10.0 || ^11.0` in 1.5.x — anyone who could install
+1.5.x against modern Drupal already had PHP 8.3+ and Twig 3+. The pruned
 `drupal/core-*` deps weren't reached by any external consumer through this
 package; consumers use the `create_attribute()` Twig function, not the Drupal
 classes directly.

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ services:
 The full API (class methods, escape semantics, `without` filter behavior) mirrors
 [Drupal's Attribute class](https://api.drupal.org/api/drupal/core%21lib%21Drupal%21Core%21Template%21Attribute.php/class/Attribute/11.x).
 
-## Upgrading from 1.0.x to 1.1.0
+## Upgrading from 1.5.x to 1.6.0
 
 **Action required: none for the vast majority of consumers.** Run
 `composer update parisek/twig-attribute`.
@@ -72,14 +72,14 @@ What changes under the hood:
   - `hasAttribute(string $name): bool` — check existence without throwing.
   - `removeClass(...$classes): static` — symmetric counterpart of `addClass`.
   - `getClass(): AttributeArray` — read the class collection.
-  - `jsonSerialize(): array` — JSON encoding support.
+  - `jsonSerialize(): string` — JSON encoding support (returns the rendered attribute string).
   - `__clone()` — deep-clone correctness.
 - The package now ships its own test suite (`tests/AttributeTest.php`,
   18 methods, pure PHPUnit). Run `vendor/bin/phpunit` to verify the
   install if you want extra confidence.
 - Composer constraints tightened to **Twig 3+ and PHP ^8.3**. Both
   were already required transitively by `drupal/core-utility ^10.0 || ^11.0`
-  in 1.0.x, so this change doesn't shrink the real install matrix.
+  in 1.5.x, so this change doesn't shrink the real install matrix.
 - Both `drupal/core-render` and `drupal/core-utility` are **no longer
   required** by this package. `Html::escape()` is inlined as a 5-LOC
   private helper. `NestedArray::mergeDeep` and `PlainTextOutput::renderFromHtml`
@@ -94,17 +94,17 @@ What changes under the hood:
   package to your own `composer.json` `require`. This is the correct
   long-term shape regardless — relying on transitive availability is
   fragile.
-- **You're on PHP < 8.3 or Twig 2.** You couldn't actually install 1.0.x
+- **You're on PHP < 8.3 or Twig 2.** You couldn't actually install 1.5.x
   cleanly against modern Drupal 10/11 either, so this is more about
   cleaning up your constraints. Bump PHP/Twig in your own project, or
-  pin `parisek/twig-attribute` to `1.0.*` to stay on the previous floor.
+  pin `parisek/twig-attribute` to `1.5.*` to stay on the previous floor.
 
 ### Direct PHP usage
 
 If your code does `new \Drupal\Component\Attribute\AttributeCollection(...)`
 in PHP (instead of using `create_attribute()` from Twig), the refresh
 adds methods but doesn't remove any. Your existing calls keep working
-in 1.1.0.
+in 1.6.0.
 
 ## Development
 
@@ -126,4 +126,4 @@ for the rationale behind the inline shims that let this package drop
 - [Drupal — Pattern Lab](https://patternlab.io/)
 - [WordPress — Timber](https://wordpress.org/plugins/timber-library/)
 - [Pimcore — Templates](https://pimcore.com/en)
-- [parisek/styleguide](https://github.com/parisek/styleguide) — the package that drove the 1.1.0 refresh.
+- [parisek/styleguide](https://github.com/parisek/styleguide) — the package that drove the 1.6.0 refresh.

--- a/docs/refresh-decisions.md
+++ b/docs/refresh-decisions.md
@@ -1,4 +1,4 @@
-# Refresh decisions — 1.1.0
+# Refresh decisions — 1.6.0
 
 Captured from upstream Drupal 11.x sources fetched on 2026-05-25 (HEAD of `11.x`).
 
@@ -7,7 +7,7 @@ Captured from upstream Drupal 11.x sources fetched on 2026-05-25 (HEAD of `11.x`
 | Symbol | Used in | Call sites | Strategy |
 |---|---|---|---|
 | `Drupal\Component\Utility\Html::escape()` | `AttributeValueBase::render()`, `AttributeString::__toString()`, `AttributeArray::__toString()`, `AttributeBoolean::__toString()` | 4 | Already handled: replace with `Parisek\Twig\Internal\Escape::html()` (Task 2). |
-| `Drupal\Component\Render\MarkupInterface` | `Attribute` (implements), `Attribute::createAttributeValue()` (type check guard in the fork — upstream switched to `\Stringable`) | Interface only; class declares `implements MarkupInterface` | Define `Parisek\Twig\MarkupInterface` as a minimal interface extending `\JsonSerializable, \Stringable` with `__toString(): string`. ~10 LOC. |
+| `Drupal\Component\Render\MarkupInterface` | `Attribute` (implements), `Attribute::createAttributeValue()` (type check guard in the fork — upstream switched to `\Stringable`) | Interface only; class declares `implements MarkupInterface` | Define `Drupal\Component\Attribute\MarkupInterface` as a minimal interface extending `\JsonSerializable, \Stringable` with `__toString(): string`. ~10 LOC. |
 | `Drupal\Component\Render\PlainTextOutput::renderFromHtml()` | `Attribute::createAttributeValue()` | 1 | Inline as `Parisek\Twig\Internal\PlainTextOutput::renderFromHtml()`. Body is `html_entity_decode(strip_tags((string) $string), ENT_QUOTES, 'UTF-8')` — zero further Drupal deps. ~10 LOC. |
 | `Drupal\Component\Utility\NestedArray::mergeDeep()` | `Attribute::merge()` | 1 | Inline as `Parisek\Twig\Internal\NestedArray` carrying only `mergeDeep()` + `mergeDeepArray()`. Pure PHP, no outside deps. ~30 LOC. |
 | `Drupal\Core\Serialization\Attribute\JsonSchema` | `Attribute::__toString()` (PHP attribute `#[JsonSchema(...)]`) | 1 (decorative) | Drop the `#[JsonSchema(...)]` annotation from the ported class. It carries no runtime effect; it exists only for Drupal's JSON Schema discovery tooling. No shim needed. |
@@ -49,7 +49,7 @@ return html_entity_decode(strip_tags((string) $string), ENT_QUOTES, 'UTF-8');
 
 Estimated LOC: ~10 (class shell + docblock + method). No further deps.
 
-### `Parisek\Twig\MarkupInterface`
+### `Drupal\Component\Attribute\MarkupInterface`
 
 File: `src/MarkupInterface.php` (public namespace, not `Internal\` — it forms part of the package's public API because consumers may pass objects implementing it)
 

--- a/src/AttributeArray.php
+++ b/src/AttributeArray.php
@@ -9,16 +9,16 @@ use Parisek\Twig\Internal\Escape;
 /**
  * A class that defines a type of Attribute that can be added to as an array.
  *
- * To use with Attribute, the array must be specified.
- * Correct:
+ * To use with AttributeCollection, the array can be specified explicitly,
+ * or the `class` key may be appended to without prior initialization —
+ * `AttributeCollection::offsetGet('class')` lazily initializes an empty
+ * AttributeArray for the special-case `class` key.
  * @code
- *  $attributes = new Attribute();
+ *  $attributes = new AttributeCollection();
  *  $attributes['class'] = [];
  *  $attributes['class'][] = 'cat';
- * @endcode
- * Incorrect:
- * @code
- *  $attributes = new Attribute();
+ *  // or, equivalently, relying on the lazy init:
+ *  $attributes = new AttributeCollection();
  *  $attributes['class'][] = 'cat';
  * @endcode
  *

--- a/src/AttributeBoolean.php
+++ b/src/AttributeBoolean.php
@@ -13,9 +13,9 @@ use Parisek\Twig\Internal\Escape;
  * They are attributes that if they exist in the tag, they are TRUE.
  * Examples include selected, disabled, checked, readonly.
  *
- * To set a boolean attribute on the Attribute class, set it to TRUE.
+ * To set a boolean attribute on the AttributeCollection class, set it to TRUE.
  * @code
- *  $attributes = new Attribute();
+ *  $attributes = new AttributeCollection();
  *  $attributes['disabled'] = TRUE;
  *  echo '<select' . $attributes . '/>';
  *  // produces <select disabled>;

--- a/src/AttributeCollection.php
+++ b/src/AttributeCollection.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Drupal\Component\Attribute;
 
-use Parisek\Twig\Internal\Escape;
 use Parisek\Twig\Internal\NestedArray;
 use Parisek\Twig\Internal\PlainTextOutput;
 

--- a/src/AttributeString.php
+++ b/src/AttributeString.php
@@ -9,10 +9,10 @@ use Parisek\Twig\Internal\Escape;
 /**
  * A class that represents most standard HTML attributes.
  *
- * To use with the Attribute class, set the key to be the attribute name
- * and the value the attribute value.
+ * To use with the AttributeCollection class, set the key to be the attribute
+ * name and the value the attribute value.
  * @code
- *  $attributes = new Attribute([]);
+ *  $attributes = new AttributeCollection([]);
  *  $attributes['id'] = 'socks';
  *  $attributes['style'] = 'background-color:white';
  *  echo '<cat ' . $attributes . '>';

--- a/src/MarkupInterface.php
+++ b/src/MarkupInterface.php
@@ -7,9 +7,11 @@ namespace Drupal\Component\Attribute;
 /**
  * Marker interface for objects safe to render as already-trusted HTML.
  *
- * Replaces Drupal\Component\Render\MarkupInterface. AttributeCollection
- * still implements this so consumers that do `instanceof MarkupInterface`
- * keep working after the drupal/core-render dependency is dropped.
+ * A local replacement for Drupal\Component\Render\MarkupInterface — the FQCN
+ * is different (Drupal\Component\Attribute\MarkupInterface), so consumers that
+ * type-check against the original Drupal interface will need to update their
+ * imports. AttributeCollection implements this so that `__toString()` and
+ * `jsonSerialize()` semantics are advertised at the type level.
  */
 interface MarkupInterface extends \JsonSerializable, \Stringable
 {

--- a/tests/AttributeTest.php
+++ b/tests/AttributeTest.php
@@ -8,7 +8,6 @@ use Drupal\Component\Attribute\AttributeArray;
 use Drupal\Component\Attribute\AttributeBoolean;
 use Drupal\Component\Attribute\AttributeCollection as Attribute;
 use Drupal\Component\Attribute\AttributeString;
-use Drupal\Component\Attribute\AttributeValueBase;
 
 use Parisek\Twig\Internal\Escape;
 
@@ -264,15 +263,18 @@ class AttributeTest extends TestCase {
 
     // Remove multiple classes.
     $attribute->removeClass('xx', 'yy');
-    $this->assertNotContains(['xx', 'yy'], $attribute['class']->value());
+    $this->assertNotContains('xx', $attribute['class']->value());
+    $this->assertNotContains('yy', $attribute['class']->value());
 
     // Remove an array of classes.
     $attribute->removeClass(['red', 'green', 'blue']);
-    $this->assertNotContains(['red', 'green', 'blue'], $attribute['class']->value());
+    $this->assertNotContains('red', $attribute['class']->value());
+    $this->assertNotContains('green', $attribute['class']->value());
+    $this->assertNotContains('blue', $attribute['class']->value());
 
     // Remove a class that does not exist.
     $attribute->removeClass('gg');
-    $this->assertNotContains(['gg'], $attribute['class']->value());
+    $this->assertNotContains('gg', $attribute['class']->value());
     // Test that the array index remains sequential.
     $this->assertEquals(['aa'], $attribute['class']->value());
 

--- a/tests/SmokeTest.php
+++ b/tests/SmokeTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Parisek\Twig\Tests;
 
-use Drupal\Component\Attribute\AttributeCollection;
 use Parisek\Twig\AttributeExtension;
 use PHPUnit\Framework\TestCase;
 use Twig\Environment;


### PR DESCRIPTION
Follow-up to #7. Resolves all 13 Copilot inline comments and aligns the version label with the repo's actual tag history (v1.0.0–v1.5.0 exist; next is v1.6.0, not v1.1.0).

## Test correctness fix

`AttributeTest::testRemoveClasses` had 3 \`assertNotContains([items], $array)\` calls where the needle was an array and the haystack was an array of strings — PHPUnit looks for the array as a single element and never finds it, so the assertions were silent no-ops. Unrolled into one assertion per string. Suite goes from 107 → 110 assertions; the +3 are the assertions that were missing.

## Doc + dead code

- jsonSerialize() return type fixed (was \`array\` in docs, impl returns string).
- AttributeCollection drops unused \`use Internal\Escape\` (Escape lives in the leaf classes' bodies, AttributeCollection only references it in docblocks).
- SmokeTest + AttributeTest drop unused imports.
- AttributeString/Boolean docblock examples now use the actual class name \`AttributeCollection\` instead of upstream's \`Attribute\`.
- AttributeArray docblock — the "Incorrect" warning about array-append-before-init is gone; \`offsetGet('class')\` lazily initializes, both styles work.
- MarkupInterface docblock — tightens the BC claim (the FQCN moved, so old \`instanceof Drupal\Component\Render\MarkupInterface\` checks still need updating).
- docs/refresh-decisions.md — fixed stale \`Parisek\Twig\MarkupInterface\` references.

## Versioning

Renamed 1.1.0 → 1.6.0 across CHANGELOG, README upgrade section, decisions doc. Date stamped 2026-05-25 on the CHANGELOG heading.

## Test plan

- [x] \`vendor/bin/phpunit\` → \`OK (41 tests, 110 assertions)\` locally (+3 from the unrolled assertNotContains)
- [x] \`vendor/bin/phpstan analyse\` → \`[OK] No errors\`
- [ ] CI passes on PHP 8.3 + 8.4 matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)